### PR TITLE
ci: only run release job on `main` branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,9 +17,11 @@ steps:
         from_secret: github_token
     image: node:alpine
     name: release
+    when:
+      branch:
+        - main
 trigger:
-  branch:
-    - main
   event:
+    - pull_request
     - push
 type: kubernetes

--- a/.drone.yml
+++ b/.drone.yml
@@ -17,11 +17,9 @@ steps:
         from_secret: github_token
     image: node:alpine
     name: release
-    when:
-      branch:
-        - main
 trigger:
+  branch:
+    - main
   event:
-    - pull_request
     - push
 type: kubernetes

--- a/.drone.yml
+++ b/.drone.yml
@@ -21,5 +21,6 @@ trigger:
   branch:
     - main
   event:
+    - pull_request
     - push
 type: kubernetes


### PR DESCRIPTION
Testing to ensure that the `when` directive for the `release` job is triggered for only push events to the `main` branch.